### PR TITLE
Add option to disable https

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ fetchTranscript('videoId_or_URL', {
   .catch(console.error);
 ```
 
+### Disable HTTPS
+
+You can disable HTTPS by setting the `https` option to `false`. This is useful if you are using a proxy that does not support HTTPS.
+
+```javascript
+fetchTranscript('videoId_or_URL', {
+  https: false,
+})
+  .then(console.log)
+  .catch(console.error);
+```
+
 ### Language Support
 
 You can specify the language for the transcript using the `lang` option.

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "format": "prettier --write 'src/**/*.ts'",
     "test": "jest",
     "test:watch": "jest --watch",
-    "prepare": "husky"
+    "prepare": "husky install && npm run build"
   },
-  "author": "ericmmartin",
+  "author": "Jonathan Coleman",
   "keywords": [
     "youtube",
     "transcript"

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {
 import { TranscriptConfig, TranscriptResponse } from './types';
 
 export class YoutubeTranscript {
-  constructor(private config?: TranscriptConfig & { cacheTTL?: number }) {}
+  constructor(private config: TranscriptConfig & { cacheTTL?: number } = { https: true }) {}
 
   async fetchTranscript(videoId: string): Promise<TranscriptResponse[]> {
     const identifier = retrieveVideoId(videoId);
@@ -33,7 +33,7 @@ export class YoutubeTranscript {
 
     // Fetch the video page
     const videoPageResponse = await videoFetch({
-      url: `https://www.youtube.com/watch?v=${identifier}`,
+      url: `${this.config?.https ? 'https' : 'http'}://www.youtube.com/watch?v=${identifier}`,
       lang: this.config?.lang,
       userAgent,
     });
@@ -88,7 +88,7 @@ export class YoutubeTranscript {
       this.config?.lang
         ? captions.captionTracks.find((track) => track.languageCode === this.config?.lang)
         : captions.captionTracks[0]
-    ).baseUrl;
+    ).baseUrl.replace('https', this.config?.https ? 'https' : 'http');
 
     // Fetch the transcript
     const transcriptResponse = await transcriptFetch({

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export interface TranscriptConfig {
   userAgent?: string;
   cache?: CacheStrategy;
   cacheTTL?: number;
+  https?: boolean;
   videoFetch?: (params: { url: string; lang?: string; userAgent?: string }) => Promise<Response>;
   transcriptFetch?: (params: {
     url: string;


### PR DESCRIPTION
Feel free to reject this but thought I'd share it just in case it is useful to anyone. I am using Zyte and don't want to deal with trying to get a certificate installed on my production host. Getting the video and transcript via HTTP works just fine. MIght need to pull out the `prepare` change I made though.