### PR TITLE
Add disableHttps option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,20 @@ fetchTranscript('videoId_or_URL', {
   .catch(console.error);
 ```
 
+### HTTP Support
+
+You can disable HTTPS and use HTTP instead for YouTube requests by setting the `disableHttps` option to `true`. This might be necessary in certain environments where HTTPS connections are restricted.
+
+```javascript
+fetchTranscript('videoId_or_URL', {
+  disableHttps: true, // Use HTTP instead of HTTPS
+})
+  .then(console.log)
+  .catch(console.error);
+```
+
+**Security Warning:** Using HTTP instead of HTTPS removes transport layer security and is not recommended for production environments. Only use this option when absolutely necessary.
+
 ### Custom Fetch Functions
 
 You can inject custom `videoFetch` and `transcriptFetch` functions to modify the fetch behavior, such as using a proxy or custom headers.
@@ -188,6 +202,7 @@ Fetches the transcript for a YouTube video.
   - **`userAgent`**: Custom User-Agent string.
   - **`cache`**: Custom caching strategy.
   - **`cacheTTL`**: Time-to-live for cache entries in milliseconds.
+  - **`disableHttps`**: Set to `true` to use HTTP instead of HTTPS for YouTube requests.
   - **`videoFetch`**: Custom fetch function for the video page request.
   - **`transcriptFetch`**: Custom fetch function for the transcript request.
 

--- a/example/http-usage.js
+++ b/example/http-usage.js
@@ -1,0 +1,17 @@
+import { fetchTranscript } from 'youtube-transcript-plus';
+
+async function main() {
+  try {
+    const videoId = 'dQw4w9WgXcQ';
+    const transcript = await fetchTranscript(videoId, {
+      disableHttps: true, // Use HTTP instead of HTTPS
+    });
+
+    console.log('Transcript fetched successfully using HTTP:');
+    console.log(transcript);
+  } catch (error) {
+    console.error('Error fetching transcript:', error.message);
+  }
+}
+
+main();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "youtube-transcript-plus",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "youtube-transcript-plus",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-transcript-plus",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Fetch transcript from a YouTube video",
   "type": "module",
   "main": "dist/youtube-transcript-plus.js",

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -40,6 +40,34 @@ describe('YoutubeTranscript', () => {
       YoutubeTranscriptNotAvailableLanguageError,
     );
   });
+
+  it('should construct URLs with HTTP when disableHttps is true', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      text: () =>
+        Promise.resolve(
+          '<div id="player">{"captions":{"playerCaptionsTracklistRenderer":{"captionTracks":[{"baseUrl":"https://example.com/transcript","languageCode":"en"}]}}}</div>',
+        ),
+    });
+
+    global.fetch = mockFetch;
+
+    const transcriptFetcher = new YoutubeTranscript({ disableHttps: true });
+    const videoId = 'dQw4w9WgXcQ';
+
+    try {
+      await transcriptFetcher.fetchTranscript(videoId);
+    } catch (e) {}
+
+    // Check that the URL used HTTP protocol
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringMatching(/^http:\/\/www\.youtube\.com/),
+      expect.anything(),
+    );
+
+    // Restore the original fetch
+    jest.restoreAllMocks();
+  });
 });
 
 describe('retrieveVideoId', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,9 +31,11 @@ export class YoutubeTranscript {
       }
     }
 
+    const protocol = this.config?.disableHttps ? 'http' : 'https';
+
     // Fetch the video page
     const videoPageResponse = await videoFetch({
-      url: `https://www.youtube.com/watch?v=${identifier}`,
+      url: `${protocol}://www.youtube.com/watch?v=${identifier}`,
       lang: this.config?.lang,
       userAgent,
     });
@@ -84,11 +86,15 @@ export class YoutubeTranscript {
       );
     }
 
-    const transcriptURL = (
+    const captionURL = (
       this.config?.lang
         ? captions.captionTracks.find((track) => track.languageCode === this.config?.lang)
         : captions.captionTracks[0]
     ).baseUrl;
+
+    const transcriptURL = this.config?.disableHttps
+      ? captionURL.replace('https://', 'http://')
+      : captionURL;
 
     // Fetch the transcript
     const transcriptResponse = await transcriptFetch({

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export interface TranscriptConfig {
   userAgent?: string;
   cache?: CacheStrategy;
   cacheTTL?: number;
+  disableHttps?: boolean;
   videoFetch?: (params: { url: string; lang?: string; userAgent?: string }) => Promise<Response>;
   transcriptFetch?: (params: {
     url: string;


### PR DESCRIPTION
This pull request introduces a new feature to allow the use of HTTP instead of HTTPS for YouTube requests. This change includes updates to the documentation, examples, tests, and core functionality to support this feature.

Key changes include:

### Documentation Updates:
* Added a new section in `README.md` explaining the `disableHttps` option and its usage.
* Updated the options list in `README.md` to include the new `disableHttps` option.

### Code Implementation:
* Introduced the `disableHttps` option in the `TranscriptConfig` interface in `src/types.ts`.
* Modified the `YoutubeTranscript` class in `src/index.ts` to construct URLs with HTTP when `disableHttps` is true. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R34-R38) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L87-R98)

### Examples and Tests:
* Added a new example file `example/http-usage.js` demonstrating how to use the `disableHttps` option.
* Added a new test case in `src/__tests__/index.test.ts` to verify that URLs are constructed with HTTP when `disableHttps` is true.

### Version Update:
* Updated the version in `package.json` from `1.0.3` to `1.0.4`.