### PR TITLE
fix: address code review findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm ci
+    - run: npm run lint
+    - run: npm run typecheck
     - run: npm run build
     - run: npm test

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ fetchTranscript('videoId_or_URL', {
 
 ### Error Handling
 
-The library throws specific errors for different failure scenarios. Make sure to handle them appropriately.
+The library throws specific errors for different failure scenarios. Each error includes a `videoId` property for programmatic handling.
 
 ```javascript
 import {
@@ -183,13 +183,13 @@ fetchTranscript('videoId_or_URL')
   .then(console.log)
   .catch((error) => {
     if (error instanceof YoutubeTranscriptVideoUnavailableError) {
-      console.error('Video is unavailable:', error.message);
+      console.error('Video is unavailable:', error.videoId);
     } else if (error instanceof YoutubeTranscriptDisabledError) {
-      console.error('Transcripts are disabled for this video:', error.message);
+      console.error('Transcripts are disabled:', error.videoId);
     } else if (error instanceof YoutubeTranscriptNotAvailableError) {
-      console.error('No transcript available:', error.message);
+      console.error('No transcript available:', error.videoId);
     } else if (error instanceof YoutubeTranscriptNotAvailableLanguageError) {
-      console.error('Transcript not available in the specified language:', error.message);
+      console.error('Language not available:', error.lang, error.availableLangs);
     } else {
       console.error('An unexpected error occurred:', error.message);
     }
@@ -208,6 +208,14 @@ The repository includes several example files in the `example/` directory to dem
 6. **`custom-fetch-usage.js`**: Shows how to use all three custom fetch functions (`videoFetch`, `playerFetch`, `transcriptFetch`) with logging and custom headers.
 
 These examples can be found in the `example/` directory of the repository.
+
+### TypeScript Types
+
+All types are exported for TypeScript consumers:
+
+```typescript
+import type { TranscriptConfig, TranscriptResponse, FetchParams, CacheStrategy } from 'youtube-transcript-plus';
+```
 
 ### API
 
@@ -237,10 +245,11 @@ Returns a `Promise<TranscriptResponse[]>` where each item in the array represent
 
 The library throws the following errors:
 
-- **`YoutubeTranscriptVideoUnavailableError`**: The video is unavailable or has been removed.
-- **`YoutubeTranscriptDisabledError`**: Transcripts are disabled for the video.
-- **`YoutubeTranscriptNotAvailableError`**: No transcript is available for the video.
-- **`YoutubeTranscriptNotAvailableLanguageError`**: The transcript is not available in the specified language.
+- **`YoutubeTranscriptVideoUnavailableError`**: The video is unavailable or has been removed. Properties: `videoId`.
+- **`YoutubeTranscriptDisabledError`**: Transcripts are disabled for the video. Properties: `videoId`.
+- **`YoutubeTranscriptNotAvailableError`**: No transcript is available for the video. Properties: `videoId`.
+- **`YoutubeTranscriptNotAvailableLanguageError`**: The transcript is not available in the specified language. Properties: `videoId`, `lang`, `availableLangs`.
+- **`YoutubeTranscriptTooManyRequestError`**: YouTube is rate-limiting requests from your IP.
 - **`YoutubeTranscriptInvalidVideoIdError`**: The provided video ID or URL is invalid.
 
 ## License

--- a/example/custom-fetch-usage.js
+++ b/example/custom-fetch-usage.js
@@ -1,4 +1,4 @@
-import { YoutubeTranscript } from 'youtube-transcript-plus.js';
+import { YoutubeTranscript } from 'youtube-transcript-plus';
 
 // Example showing how to use custom fetch functions for all three API calls
 // This is useful for proxy support, custom headers, or logging

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "nock": "^14.0.10",
         "prettier": "^3.6.2",
         "rollup": "^4.46.4",
-        "rollup-plugin-typescript": "^1.0.1",
         "rollup-plugin-typescript2": "^0.36.0",
         "ts-jest": "^29.4.1",
         "tslib": "^2.8.1",
@@ -63,7 +62,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1915,7 +1913,6 @@
       "integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.1",
         "@typescript-eslint/types": "8.50.1",
@@ -2422,7 +2419,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2693,7 +2689,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3204,7 +3199,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3639,16 +3633,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -3817,19 +3801,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -3959,22 +3930,6 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -4168,7 +4123,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -5522,13 +5476,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
@@ -5773,27 +5720,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.16.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
@@ -5873,7 +5799,6 @@
       "integrity": "sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -5910,22 +5835,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/rollup-plugin-typescript": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript/-/rollup-plugin-typescript-1.0.1.tgz",
-      "integrity": "sha512-rwJDNn9jv/NsKZuyBb/h0jsclP4CJ58qbvZt2Q9zDIGILF2LtdtvCqMOL+Gq9IVq5MTrTlHZNrn8h7VjQgd8tw==",
-      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-typescript.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve": "^1.10.0",
-        "rollup-pluginutils": "^2.5.0"
-      },
-      "peerDependencies": {
-        "tslib": "*",
-        "typescript": ">=2.1.0"
-      }
-    },
     "node_modules/rollup-plugin-typescript2": {
       "version": "0.36.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.36.0.tgz",
@@ -5956,23 +5865,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/rollup-pluginutils": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
-      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "estree-walker": "^0.6.1"
-      }
-    },
-    "node_modules/rollup-pluginutils/node_modules/estree-walker": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -6325,19 +6217,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/synckit": {
       "version": "0.11.11",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
@@ -6432,7 +6311,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6557,8 +6435,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -6602,7 +6479,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "nock": "^14.0.10",
     "prettier": "^3.6.2",
     "rollup": "^4.46.4",
-    "rollup-plugin-typescript": "^1.0.1",
     "rollup-plugin-typescript2": "^0.36.0",
     "ts-jest": "^29.4.1",
     "tslib": "^2.8.1",

--- a/src/__tests__/fixtures/transcript-entities.xml
+++ b/src/__tests__/fixtures/transcript-entities.xml
@@ -1,0 +1,2 @@
+<text start="0" dur="1.5">rock &amp; roll</text>
+<text start="1.5" dur="2.0">it&#39;s a &quot;test&quot;</text>

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -314,10 +314,7 @@ describe('YoutubeTranscript Error Handling', () => {
 
   it('should throw YoutubeTranscriptVideoUnavailableError when player endpoint returns non-OK', async () => {
     mockWatchPage();
-    nock('https://www.youtube.com')
-      .post('/youtubei/v1/player')
-      .query({ key: API_KEY })
-      .reply(500);
+    nock('https://www.youtube.com').post('/youtubei/v1/player').query({ key: API_KEY }).reply(500);
 
     const transcriptFetcher = new YoutubeTranscript();
     await expect(transcriptFetcher.fetchTranscript(VIDEO_ID)).rejects.toThrow(

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { defaultFetch, retrieveVideoId } from '../utils';
+import { defaultFetch, retrieveVideoId, decodeXmlEntities } from '../utils';
 import { YoutubeTranscriptInvalidVideoIdError } from '../errors';
 
 // Mock global fetch
@@ -149,5 +149,44 @@ describe('retrieveVideoId', () => {
     expect(() => retrieveVideoId('https://example.com')).toThrow(
       YoutubeTranscriptInvalidVideoIdError,
     );
+  });
+
+  it('should reject 11-character strings with special characters', () => {
+    expect(() => retrieveVideoId('../.././../.')).toThrow(YoutubeTranscriptInvalidVideoIdError);
+    expect(() => retrieveVideoId('hello world')).toThrow(YoutubeTranscriptInvalidVideoIdError);
+    expect(() => retrieveVideoId('abc!@#$%^&*')).toThrow(YoutubeTranscriptInvalidVideoIdError);
+  });
+
+  it('should accept valid 11-character video IDs with hyphens and underscores', () => {
+    expect(retrieveVideoId('abc_def-123')).toBe('abc_def-123');
+    expect(retrieveVideoId('___________')).toBe('___________');
+    expect(retrieveVideoId('-----------')).toBe('-----------');
+  });
+});
+
+describe('decodeXmlEntities', () => {
+  it('should decode &amp; to &', () => {
+    expect(decodeXmlEntities('rock &amp; roll')).toBe('rock & roll');
+  });
+
+  it('should decode &#39; and &apos; to single quote', () => {
+    expect(decodeXmlEntities("it&#39;s")).toBe("it's");
+    expect(decodeXmlEntities("it&apos;s")).toBe("it's");
+  });
+
+  it('should decode &quot; to double quote', () => {
+    expect(decodeXmlEntities('a &quot;test&quot;')).toBe('a "test"');
+  });
+
+  it('should decode &lt; and &gt;', () => {
+    expect(decodeXmlEntities('&lt;tag&gt;')).toBe('<tag>');
+  });
+
+  it('should handle multiple entities in one string', () => {
+    expect(decodeXmlEntities('A &amp; B &lt; C &gt; D')).toBe('A & B < C > D');
+  });
+
+  it('should return plain text unchanged', () => {
+    expect(decodeXmlEntities('Hello world')).toBe('Hello world');
   });
 });

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -170,8 +170,8 @@ describe('decodeXmlEntities', () => {
   });
 
   it('should decode &#39; and &apos; to single quote', () => {
-    expect(decodeXmlEntities("it&#39;s")).toBe("it's");
-    expect(decodeXmlEntities("it&apos;s")).toBe("it's");
+    expect(decodeXmlEntities('it&#39;s')).toBe("it's");
+    expect(decodeXmlEntities('it&apos;s')).toBe("it's");
   });
 
   it('should decode &quot; to double quote', () => {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -8,33 +8,46 @@ export class YoutubeTranscriptTooManyRequestError extends Error {
 }
 
 export class YoutubeTranscriptVideoUnavailableError extends Error {
+  public readonly videoId: string;
+
   constructor(videoId: string) {
     super(
       `The video with ID "${videoId}" is no longer available or has been removed. Please check the video URL or ID and try again.`,
     );
     this.name = 'YoutubeTranscriptVideoUnavailableError';
+    this.videoId = videoId;
   }
 }
 
 export class YoutubeTranscriptDisabledError extends Error {
+  public readonly videoId: string;
+
   constructor(videoId: string) {
     super(
       `Transcripts are disabled for the video with ID "${videoId}". This may be due to the video owner disabling captions or the video not supporting transcripts.`,
     );
     this.name = 'YoutubeTranscriptDisabledError';
+    this.videoId = videoId;
   }
 }
 
 export class YoutubeTranscriptNotAvailableError extends Error {
+  public readonly videoId: string;
+
   constructor(videoId: string) {
     super(
       `No transcripts are available for the video with ID "${videoId}". This may be because the video does not have captions or the captions are not accessible.`,
     );
     this.name = 'YoutubeTranscriptNotAvailableError';
+    this.videoId = videoId;
   }
 }
 
 export class YoutubeTranscriptNotAvailableLanguageError extends Error {
+  public readonly videoId: string;
+  public readonly lang: string;
+  public readonly availableLangs: string[];
+
   constructor(lang: string, availableLangs: string[], videoId: string) {
     super(
       `No transcripts are available in "${lang}" for the video with ID "${videoId}". Available languages: ${availableLangs.join(
@@ -42,6 +55,9 @@ export class YoutubeTranscriptNotAvailableLanguageError extends Error {
       )}. Please try a different language.`,
     );
     this.name = 'YoutubeTranscriptNotAvailableLanguageError';
+    this.videoId = videoId;
+    this.lang = lang;
+    this.availableLangs = availableLangs;
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,5 +27,5 @@ export interface TranscriptResponse {
   text: string;
   duration: number;
   offset: number;
-  lang?: string;
+  lang: string;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,8 +2,25 @@ import { DEFAULT_USER_AGENT, RE_YOUTUBE } from './constants';
 import { YoutubeTranscriptInvalidVideoIdError } from './errors';
 import { FetchParams } from './types';
 
+const RE_VIDEO_ID = /^[a-zA-Z0-9_-]{11}$/;
+
+const XML_ENTITIES: Record<string, string> = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#39;': "'",
+  '&apos;': "'",
+};
+
+const RE_XML_ENTITY = /&(?:amp|lt|gt|quot|apos|#39);/g;
+
+export function decodeXmlEntities(text: string): string {
+  return text.replace(RE_XML_ENTITY, (match) => XML_ENTITIES[match] ?? match);
+}
+
 export function retrieveVideoId(videoId: string): string {
-  if (videoId.length === 11) {
+  if (RE_VIDEO_ID.test(videoId)) {
     return videoId;
   }
   const matchId = videoId.match(RE_YOUTUBE);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     "noUnusedParameters": true,
     "importHelpers": true,
     "moduleResolution": "node",
-    "experimentalDecorators": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,
@@ -18,6 +17,6 @@
     "lib": ["esnext", "dom"],
     "typeRoots": ["node_modules/@types"]
   },
-  "include": ["src/*.ts"],
+  "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }


### PR DESCRIPTION
## Summary

- **Fix video ID validation bypass**: 11-character strings with special characters (e.g., `../.././../.`) were accepted without character validation. Now validated against `[a-zA-Z0-9_-]{11}`.
- **Decode XML entities in transcript text**: YouTube transcripts contain HTML entities (`&amp;`, `&#39;`, `&quot;`, etc.) that were passed through raw. Now decoded before returning to consumers.
- **Fix `disableHttps` not applied to player endpoint**: The Innertube player URL was hardcoded as `https://` regardless of the `disableHttps` config flag.
- **Fix FsCache race condition**: `mkdir` in the constructor was fire-and-forget. Now awaited before `get`/`set` operations via a ready promise.
- **Sanitize FsCache keys**: Cache keys containing colons (e.g., `yt:transcript:ID:en`) are now sanitized for cross-platform filesystem compatibility (Windows).
- **Fix `&fmt=` query param stripping**: Only stripped when it was the last URL parameter. Now works regardless of position.
- **Export missing types**: `TranscriptConfig`, `TranscriptResponse`, and `FetchParams` are now exported for TypeScript consumers.
- **Add structured data to error classes**: Errors now expose `videoId`, `lang`, and `availableLangs` as `readonly` properties for programmatic error handling.
- **Make `TranscriptResponse.lang` required**: Was typed as optional but always set in practice.
- **Remove unused `rollup-plugin-typescript` dependency**
- **Remove unused `experimentalDecorators` from tsconfig**
- **Fix tsconfig `include`** from `src/*.ts` to `src/**/*.ts` to cover subdirectories
- **Add lint and typecheck to CI workflow**

## Test plan

- [x] All existing tests pass (no regressions)
- [x] New tests added for: cache integration (4 tests), error paths (7 tests), XML entity decoding, video ID special char rejection, static method, convenience export, error structured data
- [x] Test count: 31 → 61
- [x] Coverage: 98.14% statements
- [x] `npm run build` passes
- [x] `npm run lint` passes (0 errors, 3 pre-existing `any` warnings)
- [x] `npm run typecheck` passes
- [x] All changes are backwards-compatible