### PR TITLE
fix: export public TypeScript interfaces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -192,7 +192,12 @@ export class YoutubeTranscript {
   }
 }
 
-export type { CacheStrategy } from './types';
+export type { 
+  TranscriptConfig, 
+  TranscriptResponse, 
+  FetchParams, 
+  CacheStrategy 
+} from './types';
 export { InMemoryCache, FsCache } from './cache';
 
 export * from './errors';


### PR DESCRIPTION
### Description
This PR explicitly exports the core TypeScript interfaces (`TranscriptResponse`, `TranscriptConfig`, `FetchParams`, and `CacheStrategy`) from the main entry point.

### Why is this needed?
Currently, these types are used internally but not exported to the public API. Users of the library who want to use TypeScript have to manually redefine these interfaces (e.g., `TranscriptResponse`) in their own projects to get type safety when handling the results of `fetchTranscript`.

### Changes
- Updated `src/index.ts` to explicitly export public types from `./types`.
- Used `export type` syntax to ensure zero runtime impact.

### Example Improvement
**Before:**
```typescript
import { fetchTranscript } from 'youtube-transcript-plus';

// User had to manually define this or use 'any'
interface ManualTranscriptResponse {
  text: string;
  duration: number;
  offset: number;
  lang?: string;
}

const data = await fetchTranscript('id') as ManualTranscriptResponse[];
```

**After:**
```typescript
import { fetchTranscript, TranscriptResponse } from 'youtube-transcript-plus';

const data: TranscriptResponse[] = await fetchTranscript('id');
```
