### PR TITLE
chore(deps): align declared ranges with installed versions

### DIFF
--- a/.ncurc.json
+++ b/.ncurc.json
@@ -1,0 +1,3 @@
+{
+  "reject": ["typescript"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,14 +17,14 @@
         "https-proxy-agent": "^9.1.0",
         "husky": "^9.1.7",
         "lint-staged": "^17.2.0",
-        "nock": "^14.0.11",
-        "prettier": "^3.8.1",
-        "rollup": "^4.60.0",
+        "nock": "^14.0.16",
+        "prettier": "^3.9.6",
+        "rollup": "^4.62.3",
         "rollup-plugin-typescript2": "^0.37.0",
         "tslib": "^2.8.1",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.57.2",
-        "vitest": "^4.1.2"
+        "typescript-eslint": "^8.65.0",
+        "vitest": "^4.1.10"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -53,14 +53,14 @@
     "https-proxy-agent": "^9.1.0",
     "husky": "^9.1.7",
     "lint-staged": "^17.2.0",
-    "nock": "^14.0.11",
-    "prettier": "^3.8.1",
-    "rollup": "^4.60.0",
+    "nock": "^14.0.16",
+    "prettier": "^3.9.6",
+    "rollup": "^4.62.3",
     "rollup-plugin-typescript2": "^0.37.0",
     "tslib": "^2.8.1",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.57.2",
-    "vitest": "^4.1.2"
+    "typescript-eslint": "^8.65.0",
+    "vitest": "^4.1.10"
   },
   "files": [
     "dist/*"


### PR DESCRIPTION
Follow-up to #28. No installed versions change — this only raises the declared ranges in `package.json` to match what's already in the lockfile (and what v2.0.1 was built and tested against), so `ncu` stops flagging them.

Also adds `.ncurc.json` rejecting `typescript`: typescript-eslint errors out on TS 7.0, with support planned for TS ≥7.1 (typescript-eslint/typescript-eslint#10940). This keeps a future `ncu -u` from pulling it in accidentally.

## Verification
- `ncu` → "All dependencies match the latest package versions" ✅
- `npm install` → lockfile in sync, 0 vulnerabilities ✅
- `npm test` — 122 passed | 1 skipped ✅